### PR TITLE
fix install in HACS

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,4 @@
+{
+    "name": "Fr\u00f6ling Connect",
+    "homeassistant": "2024.8.0"
+}


### PR DESCRIPTION
Fix the install by HACS. HACS requires the file `hacs.json`.

[HACS Docs: hacs.json](https://hacs.xyz/docs/publish/start/#hacsjson)