### PR TITLE
Update the froeling-connect version to 0.2.0

### DIFF
--- a/custom_components/froeling_connect/config_flow.py
+++ b/custom_components/froeling_connect/config_flow.py
@@ -115,7 +115,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_reconfigure(
-        self, user_input: dict[str:Any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> config_entries.ConfigFlowResult:
         """Handle a reconfiguration flow initialized by the user."""
         entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])

--- a/custom_components/froeling_connect/manifest.json
+++ b/custom_components/froeling_connect/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Layf21/hass-froeling-connect/issues",
   "requirements": [
-    "froeling-connect==2024.1.3"
+    "froeling-connect==0.2.0"
   ],
   "ssdp": [],
   "zeroconf": []

--- a/custom_components/froeling_connect/manifest.json
+++ b/custom_components/froeling_connect/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "froeling_connect",
   "name": "Fr\u00f6ling Connect",
-  "version": "1.0.0",
+  "version": "0.0.2",
   "codeowners": [
     "@Layf21"
   ],


### PR DESCRIPTION
This PR updates the integration to use froeling-connect version 0.2.0.
Although the version number appears lower than the previous 2024.1.3, this is intentional — the project has been migrated from calver to semver.

# Changes
No major functional changes.

A few minor breaking changes were introduced upstream, but they have been accounted for in this update.

Resolves #12 
Resolves #10 